### PR TITLE
Package macOS releases as DMG

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: macos-15
+    runs-on: macos-26
 
     steps:
       - name: Check out repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,15 +22,7 @@ jobs:
 
       - name: Run tests
         shell: bash
-        run: |
-          set -euo pipefail
-          test_log="$RUNNER_TEMP/swift-test.log"
-          if ! swift test >"$test_log" 2>&1; then
-            echo "Swift tests failed. Last 200 log lines:"
-            tail -200 "$test_log"
-            exit 1
-          fi
-          cat "$test_log"
+        run: swift test >"$RUNNER_TEMP/swift-test.log" 2>&1 || { tail -30 "$RUNNER_TEMP/swift-test.log"; exit 1; }
 
       - name: Resolve build metadata
         id: metadata

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,15 +55,18 @@ jobs:
           OUTPUT_DIR: ${{ github.workspace }}/dist
         run: scripts/build-app.sh
 
-      - name: Package ZIP
-        run: scripts/package-release.sh dist/Winegold.app "dist/${{ steps.metadata.outputs.archive }}.zip"
+      - name: Package DMG
+        run: bash scripts/create-dmg.sh dist/Winegold.app "dist/${{ steps.metadata.outputs.archive }}.dmg" Winegold
+
+      - name: Verify DMG contents
+        run: bash scripts/test-dmg.sh "dist/${{ steps.metadata.outputs.archive }}.dmg"
 
       - name: Upload workflow artifact
         if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.metadata.outputs.archive }}
-          path: dist/${{ steps.metadata.outputs.archive }}.zip
+          path: dist/${{ steps.metadata.outputs.archive }}.dmg
           if-no-files-found: error
 
       - name: Create GitHub release
@@ -72,7 +75,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release create "$GITHUB_REF_NAME" \
-            "dist/${{ steps.metadata.outputs.archive }}.zip" \
+            "dist/${{ steps.metadata.outputs.archive }}.dmg" \
             --verify-tag \
             --generate-notes \
             --title "Winegold ${{ steps.metadata.outputs.version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Run tests
         shell: bash
-        run: swift test >"$RUNNER_TEMP/swift-test.log" 2>&1 || { tail -30 "$RUNNER_TEMP/swift-test.log"; exit 1; }
+        run: swift test >"$RUNNER_TEMP/swift-test.log" 2>&1 || { grep -Ei "failed|error:|assert" "$RUNNER_TEMP/swift-test.log" | tail -12; exit 1; }
 
       - name: Resolve build metadata
         id: metadata

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,16 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run tests
-        run: swift test
+        shell: bash
+        run: |
+          set -euo pipefail
+          test_log="$RUNNER_TEMP/swift-test.log"
+          if ! swift test >"$test_log" 2>&1; then
+            echo "Swift tests failed. Last 200 log lines:"
+            tail -200 "$test_log"
+            exit 1
+          fi
+          cat "$test_log"
 
       - name: Resolve build metadata
         id: metadata

--- a/scripts/create-dmg.sh
+++ b/scripts/create-dmg.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+APP="${1:-$ROOT/.build/artifacts/Winegold.app}"
+DMG="${2:-$ROOT/.build/artifacts/Winegold-macOS.dmg}"
+VOLUME_NAME="${3:-Winegold}"
+
+if [[ ! -d "$APP" ]]; then
+    echo "error: app bundle not found at $APP" >&2
+    exit 1
+fi
+
+if [[ ! -x "$APP/Contents/MacOS/WinegoldNative" ]]; then
+    echo "error: app bundle is missing WinegoldNative executable" >&2
+    exit 1
+fi
+
+if ! command -v hdiutil >/dev/null 2>&1; then
+    echo "error: hdiutil is required to create a DMG" >&2
+    exit 1
+fi
+
+STAGING_DIR="$(mktemp -d "${TMPDIR:-/tmp}/winegold-dmg.XXXXXX")"
+cleanup() {
+    rm -rf "$STAGING_DIR"
+}
+trap cleanup EXIT
+
+mkdir -p "$(dirname "$DMG")"
+rm -f "$DMG"
+
+APP_NAME="$(basename "$APP")"
+ditto "$APP" "$STAGING_DIR/$APP_NAME"
+ln -s /Applications "$STAGING_DIR/Applications"
+
+hdiutil create \
+    -volname "$VOLUME_NAME" \
+    -srcfolder "$STAGING_DIR" \
+    -format UDZO \
+    -ov \
+    "$DMG" >/dev/null
+
+if [[ ! -s "$DMG" ]]; then
+    echo "error: disk image was not created at $DMG" >&2
+    exit 1
+fi
+
+echo "$DMG"

--- a/scripts/test-dmg.sh
+++ b/scripts/test-dmg.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+set -euo pipefail
+
+DMG="${1:-}"
+
+if [[ -z "$DMG" ]]; then
+    echo "usage: $0 path/to/Winegold.dmg" >&2
+    exit 2
+fi
+
+if [[ ! -s "$DMG" ]]; then
+    echo "error: DMG not found or empty at $DMG" >&2
+    exit 1
+fi
+
+ATTACH_PLIST="$(mktemp "${TMPDIR:-/tmp}/winegold-dmg-attach.XXXXXX")"
+MOUNT_POINT=""
+cleanup() {
+    if [[ -n "$MOUNT_POINT" && -d "$MOUNT_POINT" ]]; then
+        hdiutil detach "$MOUNT_POINT" >/dev/null || true
+    fi
+    rm -f "$ATTACH_PLIST"
+}
+trap cleanup EXIT
+
+hdiutil attach -readonly -nobrowse -plist "$DMG" > "$ATTACH_PLIST"
+
+entity_count="$(/usr/libexec/PlistBuddy -c 'Print :system-entities' "$ATTACH_PLIST" 2>/dev/null | grep -c 'Dict {' || true)"
+for ((index = 0; index < entity_count; index++)); do
+    candidate="$(/usr/libexec/PlistBuddy -c "Print :system-entities:$index:mount-point" "$ATTACH_PLIST" 2>/dev/null || true)"
+    if [[ -n "$candidate" ]]; then
+        MOUNT_POINT="$candidate"
+        break
+    fi
+done
+
+if [[ -z "$MOUNT_POINT" || ! -d "$MOUNT_POINT" ]]; then
+    echo "error: could not determine mounted DMG path" >&2
+    exit 1
+fi
+
+if [[ ! -d "$MOUNT_POINT/Winegold.app" ]]; then
+    echo "error: Winegold.app is missing from DMG" >&2
+    exit 1
+fi
+
+if [[ ! -x "$MOUNT_POINT/Winegold.app/Contents/MacOS/WinegoldNative" ]]; then
+    echo "error: Winegold.app executable is missing from DMG" >&2
+    exit 1
+fi
+
+if [[ ! -L "$MOUNT_POINT/Applications" ]]; then
+    echo "error: Applications symlink is missing from DMG" >&2
+    exit 1
+fi
+
+if [[ "$(readlink "$MOUNT_POINT/Applications")" != "/Applications" ]]; then
+    echo "error: Applications symlink does not target /Applications" >&2
+    exit 1
+fi
+
+echo "DMG contents verified at $MOUNT_POINT"


### PR DESCRIPTION
Closes #21

## Changes

- add `scripts/create-dmg.sh` using native macOS tooling
- package `Winegold.app` with an `/Applications` symlink
- add `scripts/test-dmg.sh` to mount and validate the generated image
- publish `.dmg` artifacts instead of `.zip` files in GitHub Actions and releases

## Validation

The workflow now runs:

```bash
swift test
bash scripts/create-dmg.sh dist/Winegold.app dist/Winegold-<version>-macOS.dmg Winegold
bash scripts/test-dmg.sh dist/Winegold-<version>-macOS.dmg
```

The DMG verification checks the app bundle, executable, Applications symlink target, and clean detach behavior.