### PR TITLE
Add global recipe palette and triggerless recipes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,14 +14,15 @@ permissions:
 
 jobs:
   build:
-    runs-on: macos-15
+    runs-on: macos-26
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
 
       - name: Run tests
-        run: swift test
+        shell: bash
+        run: swift test >"$RUNNER_TEMP/swift-test.log" 2>&1 || { grep -Ei "failed|error:|assert" "$RUNNER_TEMP/swift-test.log" | tail -12; exit 1; }
 
       - name: Resolve build metadata
         id: metadata
@@ -55,15 +56,18 @@ jobs:
           OUTPUT_DIR: ${{ github.workspace }}/dist
         run: scripts/build-app.sh
 
-      - name: Package ZIP
-        run: scripts/package-release.sh dist/Winegold.app "dist/${{ steps.metadata.outputs.archive }}.zip"
+      - name: Package DMG
+        run: bash scripts/create-dmg.sh dist/Winegold.app "dist/${{ steps.metadata.outputs.archive }}.dmg" Winegold
+
+      - name: Verify DMG contents
+        run: bash scripts/test-dmg.sh "dist/${{ steps.metadata.outputs.archive }}.dmg"
 
       - name: Upload workflow artifact
         if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.metadata.outputs.archive }}
-          path: dist/${{ steps.metadata.outputs.archive }}.zip
+          path: dist/${{ steps.metadata.outputs.archive }}.dmg
           if-no-files-found: error
 
       - name: Create GitHub release
@@ -72,7 +76,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release create "$GITHUB_REF_NAME" \
-            "dist/${{ steps.metadata.outputs.archive }}.zip" \
+            "dist/${{ steps.metadata.outputs.archive }}.dmg" \
             --verify-tag \
             --generate-notes \
             --title "Winegold ${{ steps.metadata.outputs.version }}"

--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ cmd:
   exec: 'echo "{input}" | pbcopy'
 ```
 
-See [Writing Winegold scripts](docs/scripting.md) for the supported format, triggers, and placeholders.
+Recipes may omit `trigger` when they do not need input. Use an `input` block with `min` and `max` when an action requires a specific number of files or folders.
+
+See [Writing Winegold scripts](docs/scripting.md) for the supported format, triggers, input rules, and placeholders.
 
 ## Security
 

--- a/Sources/WinegoldCore/Action.swift
+++ b/Sources/WinegoldCore/Action.swift
@@ -12,6 +12,8 @@ public struct Action: Identifiable, Codable, Equatable {
     public var acceptedExtensions: [String]
     public var acceptedUTIs: [String]
     public var triggerExpression: String?
+    public var minimumInputCount: Int
+    public var maximumInputCount: Int?
 
     public var executablePath: String
     public var argumentsTemplate: [String]
@@ -39,6 +41,8 @@ public struct Action: Identifiable, Codable, Equatable {
         acceptedExtensions: [String] = [],
         acceptedUTIs: [String] = [],
         triggerExpression: String? = nil,
+        minimumInputCount: Int = 0,
+        maximumInputCount: Int? = nil,
         executablePath: String,
         argumentsTemplate: [String] = [],
         workingDirectoryTemplate: String? = nil,
@@ -61,6 +65,8 @@ public struct Action: Identifiable, Codable, Equatable {
         self.acceptedExtensions = acceptedExtensions
         self.acceptedUTIs = acceptedUTIs
         self.triggerExpression = triggerExpression
+        self.minimumInputCount = minimumInputCount
+        self.maximumInputCount = maximumInputCount
         self.executablePath = executablePath
         self.argumentsTemplate = argumentsTemplate
         self.workingDirectoryTemplate = workingDirectoryTemplate

--- a/Sources/WinegoldCore/ActionMatcher.swift
+++ b/Sources/WinegoldCore/ActionMatcher.swift
@@ -5,44 +5,30 @@ public struct ActionMatcher {
 
     public func matchingActions(for files: [URL], actions: [Action]) -> [Action] {
         guard !files.isEmpty else { return [] }
-        let items = files.map { DraggedItem(executionURL: $0) }
-        return matchingActions(forItems: items, actions: actions)
+        return matchingActions(forItems: files.map { DraggedItem(executionURL: $0) }, actions: actions)
     }
 
     public func matchingActions(forItems items: [DraggedItem], actions: [Action]) -> [Action] {
         guard !items.isEmpty else { return [] }
-        let enabled = actions.filter { $0.enabled }
-        let parsedExpressions: [UUID: TriggerExpression] = Dictionary(uniqueKeysWithValues: enabled.compactMap { action in
-            guard let source = action.triggerExpression?.trimmingCharacters(in: .whitespacesAndNewlines),
-                  !source.isEmpty,
-                  let expression = try? TriggerParser().parse(source) else { return nil }
-            return (action.id, expression)
-        })
-        let itemValues = items.map { $0.values(includeInside: false) }
-        let needsInside = parsedExpressions.values.contains { $0.referencedFields.contains("inside") }
-        let itemValuesWithInside = needsInside ? items.map { $0.values(includeInside: true) } : []
+        return actions.filter { $0.enabled && matches($0, forItems: items) }
+    }
 
-        return enabled.filter { action in
-            if let source = action.triggerExpression?.trimmingCharacters(in: .whitespacesAndNewlines), !source.isEmpty {
-                guard let expression = parsedExpressions[action.id] else { return false }
-                let values = expression.referencedFields.contains("inside") ? itemValuesWithInside : itemValues
-                return values.allSatisfy { TriggerEvaluator().evaluate(expression, values: $0) }
-            }
-            let acceptedExtensions = normalizedExtensions(action.acceptedExtensions)
-            guard !acceptedExtensions.isEmpty else { return false }
-            if acceptedExtensions.contains("*") { return true }
-
-            return items.allSatisfy { item in
-                let file = item.executionURL
-                let ext = file.pathExtension.lowercased()
-                return acceptedExtensions.contains(ext)
+    public func matches(_ action: Action, forItems items: [DraggedItem]) -> Bool {
+        guard !items.isEmpty else { return false }
+        if let source = action.triggerExpression?.trimmingCharacters(in: .whitespacesAndNewlines), !source.isEmpty {
+            guard let expression = try? TriggerParser().parse(source) else { return false }
+            let includeInside = expression.referencedFields.contains("inside")
+            return items.allSatisfy {
+                TriggerEvaluator().evaluate(expression, values: $0.values(includeInside: includeInside))
             }
         }
+        let accepted = normalizedExtensions(action.acceptedExtensions)
+        guard !accepted.isEmpty else { return false }
+        if accepted.contains("*") { return true }
+        return items.allSatisfy { accepted.contains($0.executionURL.pathExtension.lowercased()) }
     }
 
     private func normalizedExtensions(_ extensions: [String]) -> [String] {
-        extensions
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
-            .filter { !$0.isEmpty }
+        extensions.map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }.filter { !$0.isEmpty }
     }
 }

--- a/Sources/WinegoldCore/ActionStore.swift
+++ b/Sources/WinegoldCore/ActionStore.swift
@@ -26,7 +26,7 @@ public struct ActionStore {
     }
 
     private var actionColumns: String {
-        "id, name, description, icon_name, enabled, accepted_extensions, accepted_utis, trigger_expression, executable_path, arguments_template, working_directory_template, output_path_template, success_message, requires_confirmation, timeout_seconds, is_favorite, display_order, created_at, updated_at, category"
+        "id, name, description, icon_name, enabled, accepted_extensions, accepted_utis, trigger_expression, executable_path, arguments_template, working_directory_template, output_path_template, success_message, requires_confirmation, timeout_seconds, is_favorite, display_order, created_at, updated_at, category, minimum_input_count, maximum_input_count"
     }
 
     public func listActions() throws -> [Action] {
@@ -81,8 +81,8 @@ public struct ActionStore {
             trigger_expression, executable_path, arguments_template, working_directory_template, output_path_template,
             success_message, requires_confirmation, timeout_seconds, is_favorite, display_order, created_at, updated_at,
             source_kind, external_id, recipe_path, recipe_hash, available, category, parent_external_id, child_action_id,
-            parent_name, local_enabled_override, local_order_override)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'recipe', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            parent_name, local_enabled_override, local_order_override, minimum_input_count, maximum_input_count)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'recipe', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(external_id) DO UPDATE SET id=excluded.id, name=excluded.name, description=excluded.description,
             icon_name=excluded.icon_name, enabled=excluded.enabled, accepted_extensions=excluded.accepted_extensions,
             accepted_utis=excluded.accepted_utis, trigger_expression=excluded.trigger_expression,
@@ -93,7 +93,8 @@ public struct ActionStore {
             recipe_hash=excluded.recipe_hash, available=excluded.available, category=excluded.category,
             parent_external_id=excluded.parent_external_id, child_action_id=excluded.child_action_id,
             parent_name=excluded.parent_name, local_enabled_override=excluded.local_enabled_override,
-            local_order_override=excluded.local_order_override
+            local_order_override=excluded.local_order_override, minimum_input_count=excluded.minimum_input_count,
+            maximum_input_count=excluded.maximum_input_count
         """)
         bindAction(derived, to: stmt)
         stmt.bindText(externalID, at: 20)
@@ -106,6 +107,8 @@ public struct ActionStore {
         if let parentName { stmt.bindText(parentName, at: 27) } else { stmt.bindNull(at: 27) }
         if let localEnabledOverride { stmt.bindInt(localEnabledOverride ? 1 : 0, at: 28) } else { stmt.bindNull(at: 28) }
         if let localOrderOverride { stmt.bindInt(localOrderOverride, at: 29) } else { stmt.bindNull(at: 29) }
+        stmt.bindInt(derived.minimumInputCount, at: 30)
+        if let maximum = derived.maximumInputCount { stmt.bindInt(maximum, at: 31) } else { stmt.bindNull(at: 31) }
         _ = stmt.step()
     }
 
@@ -113,8 +116,8 @@ public struct ActionStore {
         let stmt = try db.prepare("""
             INSERT INTO actions (id, name, description, icon_name, enabled, accepted_extensions,
             accepted_utis, trigger_expression, executable_path, arguments_template, working_directory_template,
-            output_path_template, success_message, requires_confirmation, timeout_seconds, is_favorite, display_order, created_at, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            output_path_template, success_message, requires_confirmation, timeout_seconds, is_favorite, display_order, created_at, updated_at, minimum_input_count, maximum_input_count)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """)
         bindAction(action, to: stmt)
         _ = stmt.step()
@@ -133,6 +136,8 @@ public struct ActionStore {
                 acceptedExtensions: action.acceptedExtensions,
                 acceptedUTIs: action.acceptedUTIs,
                 triggerExpression: action.triggerExpression,
+                minimumInputCount: action.minimumInputCount,
+                maximumInputCount: action.maximumInputCount,
                 executablePath: action.executablePath,
                 argumentsTemplate: action.argumentsTemplate,
                 workingDirectoryTemplate: action.workingDirectoryTemplate,
@@ -166,7 +171,7 @@ public struct ActionStore {
             UPDATE actions SET name=?, description=?, icon_name=?, enabled=?, accepted_extensions=?,
             accepted_utis=?, trigger_expression=?, executable_path=?, arguments_template=?, working_directory_template=?,
             output_path_template=?, success_message=?, requires_confirmation=?, timeout_seconds=?, is_favorite=?,
-            display_order=?, created_at=?, updated_at=? WHERE id=?
+            display_order=?, created_at=?, updated_at=?, minimum_input_count=?, maximum_input_count=? WHERE id=?
         """)
         bindActionForUpdate(action, to: stmt)
         _ = stmt.step()
@@ -214,14 +219,14 @@ public struct ActionStore {
         let action = try rowToAction(stmt)
         return RecipeActionMetadata(
             action: action,
-            externalID: stmt.columnIsNull(at: 20) ? nil : stmt.columnText(at: 20),
-            parentExternalID: stmt.columnIsNull(at: 21) ? nil : stmt.columnText(at: 21),
-            childActionID: stmt.columnIsNull(at: 22) ? nil : stmt.columnText(at: 22),
-            parentName: stmt.columnIsNull(at: 23) ? nil : stmt.columnText(at: 23),
-            usageCount: stmt.columnInt(at: 24),
-            lastUsedAt: stmt.columnIsNull(at: 25) ? nil : dateFormatter.date(from: stmt.columnText(at: 25)),
-            localEnabledOverride: stmt.columnIsNull(at: 26) ? nil : stmt.columnInt(at: 26) != 0,
-            localOrderOverride: stmt.columnIsNull(at: 27) ? nil : stmt.columnInt(at: 27)
+            externalID: stmt.columnIsNull(at: 22) ? nil : stmt.columnText(at: 22),
+            parentExternalID: stmt.columnIsNull(at: 23) ? nil : stmt.columnText(at: 23),
+            childActionID: stmt.columnIsNull(at: 24) ? nil : stmt.columnText(at: 24),
+            parentName: stmt.columnIsNull(at: 25) ? nil : stmt.columnText(at: 25),
+            usageCount: stmt.columnInt(at: 26),
+            lastUsedAt: stmt.columnIsNull(at: 27) ? nil : dateFormatter.date(from: stmt.columnText(at: 27)),
+            localEnabledOverride: stmt.columnIsNull(at: 28) ? nil : stmt.columnInt(at: 28) != 0,
+            localOrderOverride: stmt.columnIsNull(at: 29) ? nil : stmt.columnInt(at: 29)
         )
     }
 
@@ -334,6 +339,8 @@ public struct ActionStore {
             acceptedExtensions: extsStr.isEmpty ? [] : extsStr.components(separatedBy: ","),
             acceptedUTIs: utisStr.isEmpty ? [] : utisStr.components(separatedBy: ","),
             triggerExpression: stmt.columnIsNull(at: 7) ? nil : stmt.columnText(at: 7),
+            minimumInputCount: stmt.columnInt(at: 20),
+            maximumInputCount: stmt.columnIsNull(at: 21) ? nil : stmt.columnInt(at: 21),
             executablePath: stmt.columnText(at: 8),
             argumentsTemplate: decodeArgumentsTemplate(argsStr, executablePath: stmt.columnText(at: 8)),
             workingDirectoryTemplate: stmt.columnIsNull(at: 10) ? nil : stmt.columnText(at: 10),
@@ -355,7 +362,7 @@ public struct ActionStore {
 
     private func bindActionForUpdate(_ action: Action, to stmt: Statement) {
         bindActionFields(action, to: stmt, startingAt: 1)
-        stmt.bindText(action.id.uuidString, at: 19)
+        stmt.bindText(action.id.uuidString, at: 21)
     }
 
     private func encodeArgumentsTemplate(_ arguments: [String]) -> String {
@@ -416,5 +423,7 @@ public struct ActionStore {
         stmt.bindInt(action.displayOrder, at: start + 15)
         stmt.bindText(dateFormatter.string(from: action.createdAt), at: start + 16)
         stmt.bindText(dateFormatter.string(from: action.updatedAt), at: start + 17)
+        stmt.bindInt(action.minimumInputCount, at: start + 18)
+        if let maximum = action.maximumInputCount { stmt.bindInt(maximum, at: start + 19) } else { stmt.bindNull(at: start + 19) }
     }
 }

--- a/Sources/WinegoldCore/ActionTemplateResolver.swift
+++ b/Sources/WinegoldCore/ActionTemplateResolver.swift
@@ -19,6 +19,15 @@ public struct ActionTemplateResolver {
         return resolvePlaceholders(in: template, for: DraggedItem(executionURL: inputFile))
     }
 
+
+    public func resolveWithoutInput(argumentsTemplate: [String]) -> [String] {
+        argumentsTemplate
+    }
+
+    public func resolveWithoutInput(workingDirectoryTemplate: String?) -> String? {
+        workingDirectoryTemplate
+    }
+
     public func resolve(outputPathTemplate: String?, for inputFile: URL) -> String? {
         guard let template = outputPathTemplate else { return nil }
         return resolvePlaceholders(in: template, for: DraggedItem(executionURL: inputFile))

--- a/Sources/WinegoldCore/ActionValidator.swift
+++ b/Sources/WinegoldCore/ActionValidator.swift
@@ -10,6 +10,13 @@ public struct ActionValidator {
     public init() {}
 
     public func validate(_ action: Action) -> ActionValidationStatus {
+        if let placeholder = RecipeTemplateInputValidator().missingInputPlaceholder(in: action) {
+            return .configError(reason: "\(placeholder) requires an input trigger")
+        }
+        guard action.minimumInputCount >= 0 else { return .configError(reason: "input.min must be >= 0") }
+        if let maximum = action.maximumInputCount, maximum < action.minimumInputCount {
+            return .configError(reason: "input.max must be >= input.min")
+        }
         let fm = FileManager.default
         var isDir: ObjCBool = false
         guard fm.fileExists(atPath: action.executablePath, isDirectory: &isDir) else {

--- a/Sources/WinegoldCore/KeyboardActionSelection.swift
+++ b/Sources/WinegoldCore/KeyboardActionSelection.swift
@@ -21,6 +21,11 @@ public struct KeyboardActionSelection: Equatable {
         index = (index + 1) % count
     }
 
+    public mutating func select(index: Int, count: Int) {
+        guard count > 0 else { self.index = 0; return }
+        self.index = min(max(index, 0), count - 1)
+    }
+
     public mutating func clamp(count: Int) {
         guard count > 0 else { index = 0; return }
         index = min(max(index, 0), count - 1)

--- a/Sources/WinegoldCore/Migrations.swift
+++ b/Sources/WinegoldCore/Migrations.swift
@@ -103,9 +103,10 @@ public struct Migrations {
         try ensureRecipeIndexColumns()
         try ensureMultiActionColumns()
         try ensureRunHistoryActionColumns()
+        try ensureActionInputColumns()
         let version = try currentVersion()
         if version == 0 {
-            try db.execute("INSERT INTO schema_version (version) VALUES (11)")
+            try db.execute("INSERT INTO schema_version (version) VALUES (12)")
         } else {
             if version < 2 {
                 try db.execute("ALTER TABLE actions ADD COLUMN is_favorite INTEGER NOT NULL DEFAULT 0")
@@ -147,6 +148,10 @@ public struct Migrations {
             if version < 11 {
                 try ensureRunHistoryActionColumns()
                 try db.execute("INSERT INTO schema_version (version) VALUES (11)")
+            }
+            if version < 12 {
+                try ensureActionInputColumns()
+                try db.execute("INSERT INTO schema_version (version) VALUES (12)")
             }
         }
     }
@@ -224,6 +229,13 @@ public struct Migrations {
         if !columns.contains("child_action_id") { try db.execute("ALTER TABLE run_history ADD COLUMN child_action_id TEXT") }
         if !columns.contains("parent_recipe_name") { try db.execute("ALTER TABLE run_history ADD COLUMN parent_recipe_name TEXT") }
         if !columns.contains("child_action_name") { try db.execute("ALTER TABLE run_history ADD COLUMN child_action_name TEXT") }
+    }
+
+
+    private func ensureActionInputColumns() throws {
+        let columns = try tableColumns("actions")
+        if !columns.contains("minimum_input_count") { try db.execute("ALTER TABLE actions ADD COLUMN minimum_input_count INTEGER NOT NULL DEFAULT 1") }
+        if !columns.contains("maximum_input_count") { try db.execute("ALTER TABLE actions ADD COLUMN maximum_input_count INTEGER") }
     }
 
     private func tableColumns(_ table: String) throws -> Set<String> {

--- a/Sources/WinegoldCore/PresentedAction.swift
+++ b/Sources/WinegoldCore/PresentedAction.swift
@@ -35,47 +35,49 @@ public struct ActionPresentationPolicy {
     }
 
     public func present(_ actions: [PresentedAction], query: String = "") -> [PresentedAction] {
-        let trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        let filtered = trimmedQuery.isEmpty ? actions : actions.filter { matches($0, query: trimmedQuery) }
-        let sorted = sort(filtered)
-        return Array(sorted.prefix(trimmedQuery.isEmpty ? defaultLimit : searchLimit))
+        let query = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else { return Array(sort(actions).prefix(defaultLimit)) }
+        let ranked = actions.compactMap { item -> (PresentedAction, Int)? in
+            let value = score(item, query: query)
+            return value > 0 ? (item, value) : nil
+        }.sorted { lhs, rhs in
+            if lhs.1 != rhs.1 { return lhs.1 > rhs.1 }
+            return sort([lhs.0, rhs.0]).first == lhs.0
+        }.map(\.0)
+        return Array(ranked.prefix(searchLimit))
     }
 
     public func sort(_ actions: [PresentedAction]) -> [PresentedAction] {
-        let manuallyOrderedParents = Set(actions.compactMap { item in
-            item.localOrderOverride == nil ? nil : item.parentExternalID
-        })
+        let manuallyOrderedParents = Set(actions.compactMap { $0.localOrderOverride == nil ? nil : $0.parentExternalID })
         return actions.sorted { lhs, rhs in
             if lhs.action.isFavorite != rhs.action.isFavorite { return lhs.action.isFavorite }
-
             let sameParent = lhs.parentExternalID != nil && lhs.parentExternalID == rhs.parentExternalID
             if sameParent, let parent = lhs.parentExternalID, manuallyOrderedParents.contains(parent) {
-                let leftOrder = lhs.localOrderOverride ?? Int.max
-                let rightOrder = rhs.localOrderOverride ?? Int.max
-                if leftOrder != rightOrder { return leftOrder < rightOrder }
-            } else if lhs.usageCount != rhs.usageCount {
-                return lhs.usageCount > rhs.usageCount
-            }
-
-            if lhs.action.displayOrder != rhs.action.displayOrder {
-                return lhs.action.displayOrder < rhs.action.displayOrder
-            }
+                let left = lhs.localOrderOverride ?? Int.max, right = rhs.localOrderOverride ?? Int.max
+                if left != right { return left < right }
+            } else if lhs.usageCount != rhs.usageCount { return lhs.usageCount > rhs.usageCount }
+            if lhs.action.displayOrder != rhs.action.displayOrder { return lhs.action.displayOrder < rhs.action.displayOrder }
             return lhs.action.name.localizedCaseInsensitiveCompare(rhs.action.name) == .orderedAscending
         }
     }
 
-    private func matches(_ item: PresentedAction, query: String) -> Bool {
-        let needle = query.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
-        let fields = [
-            item.action.name,
-            item.action.description,
-            item.parentName,
-            item.action.category,
-            item.childActionID,
-            item.parentExternalID
-        ].compactMap { $0 }
-        return fields.contains { field in
-            field.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current).contains(needle)
-        }
+    public func score(_ item: PresentedAction, query: String) -> Int {
+        let needle = folded(query)
+        guard !needle.isEmpty else { return 1 }
+        let name = folded(item.action.name)
+        if name == needle { return 1000 }
+        if name.hasPrefix(needle) { return 850 }
+        if name.contains(needle) { return 700 }
+        if folded(item.parentName).contains(needle) { return 600 }
+        if item.action.acceptedExtensions.map(folded).contains(where: { $0 == needle || $0.contains(needle) }) { return 550 }
+        if folded(item.action.category).contains(needle) { return 500 }
+        if folded(item.childActionID).contains(needle) || folded(item.parentExternalID).contains(needle) { return 450 }
+        if folded(item.action.description).contains(needle) { return 350 }
+        if folded(item.action.triggerExpression).contains(needle) { return 250 }
+        return 0
+    }
+
+    private func folded(_ value: String?) -> String {
+        (value ?? "").folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
     }
 }

--- a/Sources/WinegoldCore/Recipe.swift
+++ b/Sources/WinegoldCore/Recipe.swift
@@ -106,9 +106,13 @@ public struct RecipeParser {
         var document = try parse(text: text)
         let externalID = document.id ?? Self.generatedID()
         document.id = externalID
-        let triggerNode: TriggerExpression
-        do { triggerNode = try TriggerParser().parse(document.trigger) }
-        catch { throw RecipeError.invalidTrigger(document.trigger) }
+        let triggerNode: TriggerExpression?
+        if document.trigger.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            triggerNode = nil
+        } else {
+            do { triggerNode = try TriggerParser().parse(document.trigger) }
+            catch { throw RecipeError.invalidTrigger(document.trigger) }
+        }
         let actions = document.resolvedActions(recipeURL: url, triggerNode: triggerNode)
         let warnings = (!document.actions.isEmpty && !document.command.isEmpty)
             ? ["Recipe \"\(document.name)\" defines both cmd and actions. The top-level cmd was ignored."]
@@ -166,7 +170,9 @@ public struct RecipeParser {
         case "false", "no", "0": enabled = false
         default: throw RecipeError.invalidBoolean(enabledText)
         }
-        _ = try TriggerParser().parse(trigger)
+        if !trigger.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            _ = try TriggerParser().parse(trigger)
+        }
         let variables = try RecipeVariableParser().parseVariables(lines: lines)
         return RecipeDocument(
             id: scalar("id", lines: lines),
@@ -190,7 +196,7 @@ public struct RecipeParser {
     private func triggerValue(lines: [String]) throws -> String {
         if let direct = scalar("trigger", lines: lines), !direct.isEmpty { return direct }
         let extensions = nestedList(section: "trigger", key: "fileExtension", lines: lines)
-        guard !extensions.isEmpty else { throw RecipeError.missingField("trigger") }
+        guard !extensions.isEmpty else { return "" }
         return TriggerSerializer().serialize(.condition(field: "extension", operator: .in, value: .collection(extensions)))
     }
 
@@ -308,7 +314,9 @@ public struct RecipeSerializer {
             lines.append(contentsOf: document.requirements.map { "    - \(quote($0))" })
         }
         lines.append("")
-        lines.append("trigger: \(quote(document.trigger))")
+        if !document.trigger.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            lines.append("trigger: \(quote(document.trigger))")
+        }
         if !document.actions.isEmpty {
             lines.append("")
             lines.append("actions:")
@@ -478,7 +486,7 @@ private struct RecipeRepairTextEditor {
         let serializer = RecipeSerializer()
         let replacements: [String: [String]] = [
             "name": ["name: \(serializer.quote(document.name))"],
-            "trigger": ["trigger: \(serializer.quote(document.trigger))"],
+            "trigger": document.trigger.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? [] : ["trigger: \(serializer.quote(document.trigger))"],
             "cmd": commandBlock(document.command),
             "successMessage": document.successMessage.map { ["successMessage: \(serializer.quote($0))"] } ?? []
         ]
@@ -549,7 +557,7 @@ private struct RecipeTextEditor {
         var values: [String: [String]] = [
             "name": ["name: \(serializer.quote(document.name))"],
             "enabled": ["enabled: \(document.enabled ? "true" : "false")"],
-            "trigger": ["trigger: \(serializer.quote(document.trigger))"],
+            "trigger": document.trigger.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? [] : ["trigger: \(serializer.quote(document.trigger))"],
             "cmd": commandBlock(document.command)
         ]
         if let id = document.id { values["id"] = ["id: \(serializer.quote(id))"] }

--- a/Sources/WinegoldCore/Recipe.swift
+++ b/Sources/WinegoldCore/Recipe.swift
@@ -37,6 +37,8 @@ public struct RecipeDocument: Equatable {
     public var homepage: String?
     public var enabled: Bool
     public var trigger: String
+    public var minimumInputCount: Int?
+    public var maximumInputCount: Int?
     public var command: String
     public var actions: [RecipeChildAction]
     public var successMessage: String?
@@ -44,7 +46,7 @@ public struct RecipeDocument: Equatable {
     public var requirements: [String]
     public var variables: [RecipeVariable]?
 
-    public init(id: String? = nil, name: String, description: String = "", version: String? = nil, author: String? = nil, category: String? = nil, homepage: String? = nil, enabled: Bool = true, trigger: String, command: String, successMessage: String? = nil, supportFiles: [String] = [], requirements: [String] = [], variables: [RecipeVariable]? = nil, actions: [RecipeChildAction] = []) {
+    public init(id: String? = nil, name: String, description: String = "", version: String? = nil, author: String? = nil, category: String? = nil, homepage: String? = nil, enabled: Bool = true, trigger: String, minimumInputCount: Int? = nil, maximumInputCount: Int? = nil, command: String, successMessage: String? = nil, supportFiles: [String] = [], requirements: [String] = [], variables: [RecipeVariable]? = nil, actions: [RecipeChildAction] = []) {
         self.id = id
         self.name = name
         self.description = description
@@ -54,6 +56,8 @@ public struct RecipeDocument: Equatable {
         self.homepage = homepage
         self.enabled = enabled
         self.trigger = trigger
+        self.minimumInputCount = minimumInputCount
+        self.maximumInputCount = maximumInputCount
         self.command = command
         self.actions = actions
         self.successMessage = successMessage
@@ -148,6 +152,8 @@ public struct RecipeParser {
             homepage: scalar("homepage", lines: lines) ?? scalar("source", lines: lines),
             enabled: (scalar("enabled", lines: lines) ?? "true").lowercased() != "false",
             trigger: trigger,
+            minimumInputCount: nestedInt(section: "input", key: "min", lines: lines),
+            maximumInputCount: nestedInt(section: "input", key: "max", lines: lines),
             command: command,
             successMessage: scalar("successMessage", lines: lines),
             supportFiles: topLevelList("files", lines: lines),
@@ -184,6 +190,8 @@ public struct RecipeParser {
             homepage: scalar("homepage", lines: lines) ?? scalar("source", lines: lines),
             enabled: enabled,
             trigger: trigger,
+            minimumInputCount: nestedInt(section: "input", key: "min", lines: lines),
+            maximumInputCount: nestedInt(section: "input", key: "max", lines: lines),
             command: command,
             successMessage: scalar("successMessage", lines: lines),
             supportFiles: topLevelList("files", lines: lines),
@@ -222,6 +230,10 @@ public struct RecipeParser {
             return value.unquoted
         }
         return nil
+    }
+
+    private func nestedInt(section: String, key: String, lines: [String]) -> Int? {
+        nestedScalar(section: section, key: key, lines: lines).flatMap(Int.init)
     }
 
     private func nestedList(section: String, key: String, lines: [String]) -> [String] {
@@ -312,6 +324,12 @@ public struct RecipeSerializer {
             lines.append("requires:")
             lines.append("  commands:")
             lines.append(contentsOf: document.requirements.map { "    - \(quote($0))" })
+        }
+        if document.minimumInputCount != nil || document.maximumInputCount != nil {
+            lines.append("")
+            lines.append("input:")
+            if let minimum = document.minimumInputCount { lines.append("  min: \(minimum)") }
+            if let maximum = document.maximumInputCount { lines.append("  max: \(maximum)") }
         }
         lines.append("")
         if !document.trigger.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {

--- a/Sources/WinegoldCore/RecipeChildActions.swift
+++ b/Sources/WinegoldCore/RecipeChildActions.swift
@@ -113,6 +113,8 @@ extension RecipeDocument {
     func resolvedActions(recipeURL: URL, triggerNode: TriggerExpression?) -> [Action] {
         let normalizedTrigger = triggerNode.map { TriggerSerializer().serialize($0) }
         let acceptedExtensions = triggerNode.map { RecipeParser.extensions(from: $0) } ?? []
+        let minimumInputCount = minimumInputCount ?? (triggerNode == nil ? 0 : 1)
+        let maximumInputCount = maximumInputCount
         let definitions = actions.isEmpty
             ? [RecipeChildAction(id: "", name: name, description: description, iconName: "terminal", command: command, successMessage: successMessage, requiresConfirmation: false, timeoutSeconds: 120, requirements: [], enabled: enabled)]
             : actions
@@ -128,6 +130,8 @@ extension RecipeDocument {
                 enabled: enabled && child.enabled,
                 acceptedExtensions: acceptedExtensions,
                 triggerExpression: normalizedTrigger,
+                minimumInputCount: minimumInputCount,
+                maximumInputCount: maximumInputCount,
                 executablePath: "/bin/zsh",
                 argumentsTemplate: ["-lc", child.command],
                 workingDirectoryTemplate: recipeURL.deletingLastPathComponent().path,

--- a/Sources/WinegoldCore/RecipeChildActions.swift
+++ b/Sources/WinegoldCore/RecipeChildActions.swift
@@ -110,9 +110,9 @@ extension RecipeDocument {
         return actions.isEmpty ? [id] : actions.map { "\(id)/\($0.id)" }
     }
 
-    func resolvedActions(recipeURL: URL, triggerNode: TriggerExpression) -> [Action] {
-        let normalizedTrigger = TriggerSerializer().serialize(triggerNode)
-        let acceptedExtensions = RecipeParser.extensions(from: triggerNode)
+    func resolvedActions(recipeURL: URL, triggerNode: TriggerExpression?) -> [Action] {
+        let normalizedTrigger = triggerNode.map { TriggerSerializer().serialize($0) }
+        let acceptedExtensions = triggerNode.map { RecipeParser.extensions(from: $0) } ?? []
         let definitions = actions.isEmpty
             ? [RecipeChildAction(id: "", name: name, description: description, iconName: "terminal", command: command, successMessage: successMessage, requiresConfirmation: false, timeoutSeconds: 120, requirements: [], enabled: enabled)]
             : actions

--- a/Sources/WinegoldCore/RecipeInvocation.swift
+++ b/Sources/WinegoldCore/RecipeInvocation.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+public enum RecipeInputRequirement: Equatable {
+    case none
+    case files(allowedExtensions: [String])
+    case directories
+    case items
+    case unresolved
+}
+
+public struct RecipeValidationIssue: Equatable, LocalizedError {
+    public let message: String
+    public init(_ message: String) { self.message = message }
+    public var errorDescription: String? { message }
+}
+
+public enum RecipeInvocationValidationResult: Equatable {
+    case valid
+    case missingInput(RecipeInputRequirement)
+    case incompatible([RecipeValidationIssue])
+}
+
+public struct RecipeInputRequirementResolver {
+    public init() {}
+
+    public func requirement(for action: Action) -> RecipeInputRequirement {
+        guard let source = action.triggerExpression?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !source.isEmpty,
+              let expression = try? TriggerParser().parse(source) else {
+            let extensions = normalized(action.acceptedExtensions)
+            return extensions.isEmpty ? .none : .files(allowedExtensions: extensions.filter { $0 != "*" })
+        }
+        return requirement(from: expression)
+    }
+
+    private func requirement(from expression: TriggerExpression) -> RecipeInputRequirement {
+        switch expression {
+        case let .condition(field, op, literal):
+            if field == "isDirectory" || (field == "kind" && string(literal) == "directory") { return .directories }
+            if field == "isFile" || (field == "kind" && string(literal) == "file") { return .files(allowedExtensions: []) }
+            if field == "extension" {
+                if op == .in, case let .collection(values) = literal { return .files(allowedExtensions: normalized(values).filter { $0 != "*" }.sorted()) }
+                if op == .equals, let value = string(literal) { return .files(allowedExtensions: normalized([value])) }
+            }
+            return .items
+        case let .and(children):
+            let requirements = children.map(requirement(from:))
+            if requirements.contains(.directories) { return .directories }
+            let extensions = requirements.compactMap { requirement -> [String]? in
+                if case let .files(values) = requirement { return values }
+                return nil
+            }.flatMap { $0 }
+            if requirements.contains(where: { if case .files = $0 { return true }; return false }) {
+                return .files(allowedExtensions: Array(Set(extensions)).sorted())
+            }
+            return .items
+        case .or, .not:
+            return .unresolved
+        }
+    }
+
+    private func string(_ literal: TriggerLiteral?) -> String? {
+        guard case let .string(value) = literal else { return nil }
+        return value.lowercased()
+    }
+
+    private func normalized(_ values: [String]) -> [String] {
+        values.map { $0.trimmingCharacters(in: CharacterSet(charactersIn: ". ")).lowercased() }.filter { !$0.isEmpty }
+    }
+}
+
+public struct RecipeInvocationValidator {
+    public init() {}
+
+    public func validate(_ action: Action, items: [DraggedItem]) -> RecipeInvocationValidationResult {
+        let requirement = RecipeInputRequirementResolver().requirement(for: action)
+        if items.isEmpty {
+            return requirement == .none ? .valid : .missingInput(requirement)
+        }
+        guard requirement != .none else {
+            return .incompatible([RecipeValidationIssue("This recipe does not accept input.")])
+        }
+        if ActionMatcher().matches(action, forItems: items) { return .valid }
+        return .incompatible([RecipeValidationIssue(incompatibilityMessage(for: requirement))])
+    }
+
+    private func incompatibilityMessage(for requirement: RecipeInputRequirement) -> String {
+        switch requirement {
+        case let .files(extensions) where !extensions.isEmpty:
+            return "This recipe expects: " + extensions.map { ".\($0)" }.joined(separator: ", ")
+        case .files: return "This recipe expects files."
+        case .directories: return "This recipe expects a folder."
+        case .items, .unresolved: return "The selected input does not match this recipe trigger."
+        case .none: return "This recipe does not accept input."
+        }
+    }
+}

--- a/Sources/WinegoldCore/RecipeInvocation.swift
+++ b/Sources/WinegoldCore/RecipeInvocation.swift
@@ -4,6 +4,8 @@ public enum RecipeInputRequirement: Equatable {
     case none
     case files(allowedExtensions: [String])
     case directories
+    case url
+    case text
     case items
     case unresolved
 }
@@ -24,11 +26,16 @@ public struct RecipeInputRequirementResolver {
     public init() {}
 
     public func requirement(for action: Action) -> RecipeInputRequirement {
+        if action.minimumInputCount == 0,
+           action.triggerExpression?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty != false,
+           action.acceptedExtensions.isEmpty {
+            return .none
+        }
         guard let source = action.triggerExpression?.trimmingCharacters(in: .whitespacesAndNewlines),
               !source.isEmpty,
               let expression = try? TriggerParser().parse(source) else {
             let extensions = normalized(action.acceptedExtensions)
-            return extensions.isEmpty ? .none : .files(allowedExtensions: extensions.filter { $0 != "*" })
+            return extensions.isEmpty ? .items : .files(allowedExtensions: extensions.filter { $0 != "*" })
         }
         return requirement(from: expression)
     }
@@ -38,6 +45,8 @@ public struct RecipeInputRequirementResolver {
         case let .condition(field, op, literal):
             if field == "isDirectory" || (field == "kind" && string(literal) == "directory") { return .directories }
             if field == "isFile" || (field == "kind" && string(literal) == "file") { return .files(allowedExtensions: []) }
+            if field == "isURL" || field == "url" || field == "host" || field == "scheme" || (field == "kind" && string(literal) == "url") { return .url }
+            if field == "isText" || field == "text" || (field == "kind" && string(literal) == "text") { return .text }
             if field == "extension" {
                 if op == .in, case let .collection(values) = literal { return .files(allowedExtensions: normalized(values).filter { $0 != "*" }.sorted()) }
                 if op == .equals, let value = string(literal) { return .files(allowedExtensions: normalized([value])) }
@@ -46,6 +55,8 @@ public struct RecipeInputRequirementResolver {
         case let .and(children):
             let requirements = children.map(requirement(from:))
             if requirements.contains(.directories) { return .directories }
+            if requirements.contains(.url) { return .url }
+            if requirements.contains(.text) { return .text }
             let extensions = requirements.compactMap { requirement -> [String]? in
                 if case let .files(values) = requirement { return values }
                 return nil
@@ -74,14 +85,23 @@ public struct RecipeInvocationValidator {
 
     public func validate(_ action: Action, items: [DraggedItem]) -> RecipeInvocationValidationResult {
         let requirement = RecipeInputRequirementResolver().requirement(for: action)
-        if items.isEmpty {
-            return requirement == .none ? .valid : .missingInput(requirement)
+        if items.count < action.minimumInputCount {
+            return .missingInput(requirement)
         }
+        if let maximum = action.maximumInputCount, items.count > maximum {
+            return .incompatible([RecipeValidationIssue(countMessage(minimum: action.minimumInputCount, maximum: maximum))])
+        }
+        if items.isEmpty { return requirement == .none ? .valid : .missingInput(requirement) }
         guard requirement != .none else {
             return .incompatible([RecipeValidationIssue("This recipe does not accept input.")])
         }
         if ActionMatcher().matches(action, forItems: items) { return .valid }
         return .incompatible([RecipeValidationIssue(incompatibilityMessage(for: requirement))])
+    }
+
+    private func countMessage(minimum: Int, maximum: Int) -> String {
+        if minimum == maximum { return "This recipe expects exactly \(minimum) item\(minimum == 1 ? "" : "s")." }
+        return "This recipe accepts between \(minimum) and \(maximum) items."
     }
 
     private func incompatibilityMessage(for requirement: RecipeInputRequirement) -> String {
@@ -90,8 +110,22 @@ public struct RecipeInvocationValidator {
             return "This recipe expects: " + extensions.map { ".\($0)" }.joined(separator: ", ")
         case .files: return "This recipe expects files."
         case .directories: return "This recipe expects a folder."
+        case .url: return "This recipe expects a URL."
+        case .text: return "This recipe expects text."
         case .items, .unresolved: return "The selected input does not match this recipe trigger."
         case .none: return "This recipe does not accept input."
         }
+    }
+}
+
+public struct RecipeTemplateInputValidator {
+    private static let inputPlaceholders = ["{input}", "{inputPath}", "{parent}", "{filename}", "{basename}", "{extension}", "{dotExtension}", "{inside}"]
+
+    public init() {}
+
+    public func missingInputPlaceholder(in action: Action) -> String? {
+        guard action.minimumInputCount == 0 else { return nil }
+        let templates = action.argumentsTemplate + [action.workingDirectoryTemplate, action.outputPathTemplate, action.successMessage].compactMap { $0 }
+        return Self.inputPlaceholders.first { placeholder in templates.contains { $0.contains(placeholder) } }
     }
 }

--- a/Sources/WinegoldNative/ActionCardView.swift
+++ b/Sources/WinegoldNative/ActionCardView.swift
@@ -10,6 +10,7 @@ class ActionCardView: NSView {
     private let isActive: Bool
     private let isKeyboardSelected: Bool
     private let setupRequirements: RecipeSetupRequirements?
+    private let inputActionLabel: String?
     private let onDrop: ([URL]) -> Void
     private let onSetup: (Action) -> Void
     private let onToggleFavorite: (Action) -> Void
@@ -36,6 +37,7 @@ class ActionCardView: NSView {
         isActive: Bool,
         isKeyboardSelected: Bool = false,
         setupRequirements: RecipeSetupRequirements? = nil,
+        inputActionLabel: String? = nil,
         isGroupedRow: Bool = false,
         parentName: String? = nil,
         onDrop: @escaping ([URL]) -> Void,
@@ -48,6 +50,7 @@ class ActionCardView: NSView {
         self.isActive = isActive
         self.isKeyboardSelected = isKeyboardSelected
         self.setupRequirements = setupRequirements
+        self.inputActionLabel = inputActionLabel
         self.isGroupedRow = isGroupedRow
         self.parentName = parentName
         self.onDrop = onDrop
@@ -83,7 +86,7 @@ class ActionCardView: NSView {
             configureSubtitle(setupRequirements?.summary ?? subtitle)
             if setupRequirements == nil { configureFavoriteButton() }
             else { favoriteButton.isHidden = true }
-            configureRunCard(label: setupRequirements?.actionLabel)
+            configureRunCard(label: setupRequirements?.actionLabel ?? inputActionLabel)
         case .missingDependency(let reason), .configError(let reason):
             layer?.backgroundColor = WinegoldTheme.layerColor(
                 WinegoldTheme.cardBackground(in: self, disabled: true),
@@ -139,9 +142,10 @@ class ActionCardView: NSView {
         super.layout()
         let rightInset: CGFloat = 12
         let leftTextX: CGFloat = 48
-        let buttonSize = NSSize(width: setupRequirements == nil ? 34 : 116, height: 30)
+        let hasLabel = setupRequirements != nil || inputActionLabel != nil
+        let buttonSize = NSSize(width: hasLabel ? 116 : 34, height: 30)
         let buttonX = max(leftTextX + 120, bounds.width - rightInset - buttonSize.width)
-        let textRightPadding: CGFloat = caseAvailable ? (setupRequirements == nil ? 88 : 150) : 12
+        let textRightPadding: CGFloat = caseAvailable ? (hasLabel ? 150 : 88) : 12
         let textWidth = max(80, bounds.width - leftTextX - textRightPadding)
 
         leadingIcon.frame = NSRect(x: 12, y: 20, width: 24, height: 24)

--- a/Sources/WinegoldNative/ActionCardView.swift
+++ b/Sources/WinegoldNative/ActionCardView.swift
@@ -8,13 +8,14 @@ class ActionCardView: NSView {
     private let action: Action
     private let status: ActionValidationStatus
     private let isActive: Bool
-    private let isKeyboardSelected: Bool
+    private var isKeyboardSelected: Bool
     private let setupRequirements: RecipeSetupRequirements?
     private let inputActionLabel: String?
     private let onDrop: ([URL]) -> Void
     private let onSetup: (Action) -> Void
     private let onToggleFavorite: (Action) -> Void
     private let onMoveBefore: (Action, Action) -> Void
+    private let onSelection: () -> Void
     private let isGroupedRow: Bool
     private let parentName: String?
 
@@ -43,7 +44,8 @@ class ActionCardView: NSView {
         onDrop: @escaping ([URL]) -> Void,
         onSetup: @escaping (Action) -> Void = { _ in },
         onToggleFavorite: @escaping (Action) -> Void,
-        onMoveBefore: @escaping (Action, Action) -> Void
+        onMoveBefore: @escaping (Action, Action) -> Void,
+        onSelection: @escaping () -> Void = {}
     ) {
         self.action = action
         self.status = status
@@ -57,6 +59,7 @@ class ActionCardView: NSView {
         self.onSetup = onSetup
         self.onToggleFavorite = onToggleFavorite
         self.onMoveBefore = onMoveBefore
+        self.onSelection = onSelection
         super.init(frame: NSRect(x: 0, y: 0, width: 312, height: 64))
         wantsLayer = true
         layer?.cornerRadius = isGroupedRow ? 0 : 8
@@ -128,6 +131,7 @@ class ActionCardView: NSView {
 
     override func mouseEntered(with event: NSEvent) {
         guard caseAvailable else { return }
+        onSelection()
         isHovered = true
         applyVisualState(animated: true)
     }
@@ -161,6 +165,22 @@ class ActionCardView: NSView {
         )
     }
 
+
+    func setSelected(_ selected: Bool) {
+        isKeyboardSelected = selected
+        if !selected {
+            isHovered = false
+            isPressed = false
+        }
+        applyVisualState(animated: false)
+    }
+
+    func releaseInteractionState() {
+        isHovered = false
+        isPressed = false
+        applyVisualState(animated: false)
+    }
+
     override func resetCursorRects() {
         super.resetCursorRects()
         if caseAvailable {
@@ -170,6 +190,7 @@ class ActionCardView: NSView {
 
     override func mouseDown(with event: NSEvent) {
         guard caseAvailable else { return }
+        onSelection()
         isPressed = true
         applyVisualState(animated: true)
     }

--- a/Sources/WinegoldNative/ActionPanelView.swift
+++ b/Sources/WinegoldNative/ActionPanelView.swift
@@ -1,4 +1,5 @@
 import Cocoa
+import UniformTypeIdentifiers
 import WinegoldCore
 import WinegoldUI
 
@@ -31,7 +32,7 @@ class ActionPanelViewController: NSViewController, NSSearchFieldDelegate {
     private(set) var currentContentHeight: CGFloat = 0
 
     var shouldShowActions: Bool {
-        !state.files.isEmpty || !dragPreviewFiles.isEmpty || state.runningActionName != nil || state.lastResult != nil
+        !state.allActions.isEmpty || !state.files.isEmpty || !dragPreviewFiles.isEmpty || state.runningActionName != nil || state.lastResult != nil
     }
 
     var hasActiveFileDrag: Bool {
@@ -109,6 +110,9 @@ class ActionPanelViewController: NSViewController, NSSearchFieldDelegate {
 
     override func viewDidAppear() {
         super.viewDidAppear()
+        if state.files.isEmpty, actionSearchField.superview != nil {
+            view.window?.makeFirstResponder(actionSearchField)
+        }
         applyTheme()
         refresh(animatedStatusInsert: false)
     }
@@ -478,7 +482,14 @@ class ActionPanelViewController: NSViewController, NSSearchFieldDelegate {
 
     private func addActionsSection(y: inout CGFloat, w: CGFloat) {
         let dragActions = previewMatchedActions
-        let matchedActions = !dragPreviewFiles.isEmpty ? dragActions : state.actions
+        let matchedActions: [Action]
+        if !dragPreviewFiles.isEmpty {
+            matchedActions = dragActions
+        } else if state.files.isEmpty {
+            matchedActions = state.allActions.filter(\.enabled)
+        } else {
+            matchedActions = state.actions
+        }
         let presented = matchedActions.map { action -> PresentedAction in
             let metadata = state.actionMetadata[action.id]
             return PresentedAction(
@@ -499,7 +510,7 @@ class ActionPanelViewController: NSViewController, NSSearchFieldDelegate {
         contentView.addSubview(label)
         y += 20
 
-        if matchedActions.count > 10 || !actionSearchQuery.isEmpty {
+        if state.files.isEmpty || matchedActions.count > 10 || !actionSearchQuery.isEmpty {
             actionSearchField.placeholderString = "Search \(matchedActions.count) actions"
             actionSearchField.stringValue = actionSearchQuery
             actionSearchField.target = nil
@@ -538,8 +549,7 @@ class ActionPanelViewController: NSViewController, NSSearchFieldDelegate {
                 parentName: item.parentName,
                 onDrop: { [weak self] droppedFiles in
                     let files = droppedFiles.isEmpty ? (self?.state.files ?? []) : droppedFiles
-                    guard !files.isEmpty else { return }
-                    self?.startRun(action: action, files: files)
+                    self?.select(action: action, files: files)
                 },
                 onSetup: { [weak self] action in self?.onSetupAction(action, self?.state.files ?? []) },
                 onToggleFavorite: { [weak self] action in self?.onToggleFavorite(action) },
@@ -608,13 +618,67 @@ class ActionPanelViewController: NSViewController, NSSearchFieldDelegate {
         guard !visibleActionItems.isEmpty else { return }
         keyboardSelection.clamp(count: visibleActionItems.count)
         let action = visibleActionItems[keyboardSelection.index].action
-        let files = state.files
-        guard !files.isEmpty else { return }
-        if state.setupRequirements[action.id] == nil {
-            startRun(action: action, files: files)
-        } else {
+        select(action: action, files: state.files)
+    }
+
+    private func select(action: Action, files: [URL]) {
+        if state.setupRequirements[action.id] != nil {
             onSetupAction(action, files)
+            return
         }
+        let items = files.map { DraggedItem(executionURL: $0) }
+        switch RecipeInvocationValidator().validate(action, items: items) {
+        case .valid:
+            startRun(action: action, files: files)
+        case let .missingInput(requirement):
+            chooseInput(for: action, requirement: requirement)
+        case let .incompatible(issues):
+            showValidationError(issues.map(\.message).joined(separator: "\n"))
+        }
+    }
+
+    private func chooseInput(for action: Action, requirement: RecipeInputRequirement) {
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = true
+        switch requirement {
+        case let .files(extensions):
+            panel.canChooseFiles = true
+            panel.canChooseDirectories = false
+            let types = extensions.compactMap { UTType(filenameExtension: $0) }
+            if !types.isEmpty { panel.allowedContentTypes = types }
+        case .directories:
+            panel.canChooseFiles = false
+            panel.canChooseDirectories = true
+        case .items, .unresolved:
+            panel.canChooseFiles = true
+            panel.canChooseDirectories = true
+        case .none:
+            startRun(action: action, files: [])
+            return
+        }
+        let panelWindow = view.window as? ActionPanelWindow
+        panelWindow?.beginModalInteraction()
+        let response = panel.runModal()
+        panelWindow?.endModalInteraction()
+        guard response == .OK else { return }
+        let items = panel.urls.map { DraggedItem(executionURL: $0) }
+        switch RecipeInvocationValidator().validate(action, items: items) {
+        case .valid:
+            setDraggedFiles(panel.urls)
+            startRun(action: action, files: panel.urls)
+        case let .incompatible(issues):
+            showValidationError(issues.map(\.message).joined(separator: "\n"))
+        case .missingInput:
+            showValidationError("This recipe still needs input.")
+        }
+    }
+
+    private func showValidationError(_ message: String) {
+        let alert = makeAppAlert()
+        alert.messageText = "Recipe cannot run"
+        alert.informativeText = message
+        alert.alertStyle = .warning
+        alert.runModal()
     }
 
     private func addLoading(actionName: String, y: CGFloat, w: CGFloat) -> CGFloat {

--- a/Sources/WinegoldNative/ActionPanelView.swift
+++ b/Sources/WinegoldNative/ActionPanelView.swift
@@ -545,6 +545,7 @@ class ActionPanelViewController: NSViewController, NSSearchFieldDelegate {
                 isActive: state.activeActionId == action.id,
                 isKeyboardSelected: index == keyboardSelection.index,
                 setupRequirements: state.setupRequirements[action.id],
+                inputActionLabel: paletteActionLabel(for: action),
                 isGroupedRow: true,
                 parentName: item.parentName,
                 onDrop: { [weak self] droppedFiles in
@@ -572,6 +573,7 @@ class ActionPanelViewController: NSViewController, NSSearchFieldDelegate {
     func controlTextDidChange(_ obj: Notification) {
         guard obj.object as AnyObject? === actionSearchField else { return }
         actionSearchQuery = actionSearchField.stringValue
+        if state.files.isEmpty { showsRecentRuns = !actionSearchQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
         keyboardSelection.reset()
         refreshKeepingSearchFocus()
     }
@@ -638,8 +640,12 @@ class ActionPanelViewController: NSViewController, NSSearchFieldDelegate {
     }
 
     private func chooseInput(for action: Action, requirement: RecipeInputRequirement) {
+        if requirement == .url || requirement == .text {
+            chooseTextualInput(for: action, requirement: requirement)
+            return
+        }
         let panel = NSOpenPanel()
-        panel.allowsMultipleSelection = true
+        panel.allowsMultipleSelection = action.maximumInputCount != 1
         switch requirement {
         case let .files(extensions):
             panel.canChooseFiles = true
@@ -652,6 +658,8 @@ class ActionPanelViewController: NSViewController, NSSearchFieldDelegate {
         case .items, .unresolved:
             panel.canChooseFiles = true
             panel.canChooseDirectories = true
+        case .url, .text:
+            return
         case .none:
             startRun(action: action, files: [])
             return
@@ -670,6 +678,52 @@ class ActionPanelViewController: NSViewController, NSSearchFieldDelegate {
             showValidationError(issues.map(\.message).joined(separator: "\n"))
         case .missingInput:
             showValidationError("This recipe still needs input.")
+        }
+    }
+
+
+    private func chooseTextualInput(for action: Action, requirement: RecipeInputRequirement) {
+        let alert = makeAppAlert()
+        let isURL = requirement == .url
+        alert.messageText = isURL ? "Enter URL" : "Enter text"
+        alert.informativeText = isURL ? "Paste the URL required by this recipe." : "Enter the text required by this recipe."
+        alert.addButton(withTitle: "Continue")
+        alert.addButton(withTitle: "Cancel")
+        let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 360, height: isURL ? 24 : 72))
+        field.placeholderString = isURL ? "https://example.com" : "Text"
+        alert.accessoryView = field
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        let value = field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else { showValidationError("Input cannot be empty."); return }
+        if isURL, URLComponents(string: value)?.scheme == nil { showValidationError("Enter a valid URL."); return }
+        do {
+            let directory = FileManager.default.temporaryDirectory.appendingPathComponent("WinegoldPaletteInputs", isDirectory: true)
+            let file = try ContentAddressedFileStore(directory: directory).store(
+                contents: value,
+                prefix: isURL ? "dragged-url" : "dragged-text",
+                fileExtension: isURL ? "url" : "txt"
+            )
+            let item = DraggedItem(executionURL: file, kind: isURL ? .url : .text, rawURL: isURL ? value : nil, rawText: isURL ? nil : value)
+            switch RecipeInvocationValidator().validate(action, items: [item]) {
+            case .valid: startRun(action: action, files: [file])
+            case let .incompatible(issues): showValidationError(issues.map(\.message).joined(separator: "\n"))
+            case .missingInput: showValidationError("This recipe still needs input.")
+            }
+        } catch {
+            showValidationError(error.localizedDescription)
+        }
+    }
+
+    private func paletteActionLabel(for action: Action) -> String? {
+        guard state.files.isEmpty else { return nil }
+        if state.setupRequirements[action.id] != nil { return nil }
+        switch RecipeInputRequirementResolver().requirement(for: action) {
+        case .none: return "Run"
+        case .files: return "Choose file"
+        case .directories: return "Choose folder"
+        case .url: return "Enter URL"
+        case .text: return "Enter text"
+        case .items, .unresolved: return "Choose input"
         }
     }
 
@@ -1038,6 +1092,18 @@ class ActionPanelViewController: NSViewController, NSSearchFieldDelegate {
             y += 60
         }
         y += 4
+    }
+
+
+    private func matchingHistory(_ items: [RunHistoryItem]) -> [RunHistoryItem] {
+        let query = actionSearchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard state.files.isEmpty, !query.isEmpty else { return items }
+        let needle = query.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+        return items.filter { item in
+            [item.actionName, item.parentRecipeName, item.childActionName, item.inputFiles.joined(separator: " ")]
+                .compactMap { $0 }
+                .contains { $0.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current).contains(needle) }
+        }
     }
 
     private func toggleSaved(_ item: RunHistoryItem) {

--- a/Sources/WinegoldNative/ActionPanelView.swift
+++ b/Sources/WinegoldNative/ActionPanelView.swift
@@ -515,9 +515,9 @@ class ActionPanelViewController: NSViewController, NSSearchFieldDelegate {
             actionSearchField.stringValue = actionSearchQuery
             actionSearchField.target = nil
             actionSearchField.action = nil
-            actionSearchField.frame = NSRect(x: padding, y: y, width: w, height: 28)
+            actionSearchField.frame = NSRect(x: padding, y: y + 5, width: w, height: 28)
             contentView.addSubview(actionSearchField)
-            y += 36
+            y += 46
         }
 
         if visible.isEmpty {
@@ -554,7 +554,8 @@ class ActionPanelViewController: NSViewController, NSSearchFieldDelegate {
                 },
                 onSetup: { [weak self] action in self?.onSetupAction(action, self?.state.files ?? []) },
                 onToggleFavorite: { [weak self] action in self?.onToggleFavorite(action) },
-                onMoveBefore: { [weak self] source, target in self?.onMoveAction(source, target) }
+                onMoveBefore: { [weak self] source, target in self?.onMoveAction(source, target) },
+                onSelection: { [weak self] in self?.selectCard(at: index) }
             )
             card.frame = NSRect(x: 0, y: CGFloat(index) * rowHeight, width: w, height: rowHeight)
             container.addSubview(card)
@@ -570,6 +571,13 @@ class ActionPanelViewController: NSViewController, NSSearchFieldDelegate {
         y += containerHeight + 12
     }
 
+    func controlTextDidBeginEditing(_ obj: Notification) {
+        guard obj.object as AnyObject? === actionSearchField else { return }
+        keyboardSelection.reset()
+        releaseCardInteractionStates()
+        syncCardSelection()
+    }
+
     func controlTextDidChange(_ obj: Notification) {
         guard obj.object as AnyObject? === actionSearchField else { return }
         actionSearchQuery = actionSearchField.stringValue
@@ -583,10 +591,12 @@ class ActionPanelViewController: NSViewController, NSSearchFieldDelegate {
         switch commandSelector {
         case #selector(NSResponder.moveUp(_:)):
             keyboardSelection.moveUp(count: visibleActionItems.count)
+            syncCardSelection()
             refreshKeepingSearchFocus()
             return true
         case #selector(NSResponder.moveDown(_:)):
             keyboardSelection.moveDown(count: visibleActionItems.count)
+            syncCardSelection()
             refreshKeepingSearchFocus()
             return true
         case #selector(NSResponder.insertNewline(_:)):
@@ -595,6 +605,22 @@ class ActionPanelViewController: NSViewController, NSSearchFieldDelegate {
         default:
             return false
         }
+    }
+
+    private func selectCard(at index: Int) {
+        guard visibleActionItems.indices.contains(index) else { return }
+        keyboardSelection.select(index: index, count: visibleActionItems.count)
+        syncCardSelection()
+    }
+
+    private func syncCardSelection() {
+        for (index, card) in cardViews.enumerated() {
+            card.setSelected(index == keyboardSelection.index)
+        }
+    }
+
+    private func releaseCardInteractionStates() {
+        cardViews.forEach { $0.releaseInteractionState() }
     }
 
     private func refreshKeepingSearchFocus() {

--- a/Sources/WinegoldNative/ActionPanelView.swift
+++ b/Sources/WinegoldNative/ActionPanelView.swift
@@ -515,9 +515,9 @@ class ActionPanelViewController: NSViewController, NSSearchFieldDelegate {
             actionSearchField.stringValue = actionSearchQuery
             actionSearchField.target = nil
             actionSearchField.action = nil
-            actionSearchField.frame = NSRect(x: padding, y: y + 5, width: w, height: 28)
+            actionSearchField.frame = NSRect(x: padding, y: y + 10, width: w, height: 28)
             contentView.addSubview(actionSearchField)
-            y += 46
+            y += 56
         }
 
         if visible.isEmpty {

--- a/Sources/WinegoldNative/AppDelegate.swift
+++ b/Sources/WinegoldNative/AppDelegate.swift
@@ -745,6 +745,50 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         actionPanelWindow?.beginRun(actionName: action.name, files: files)
 
+        if files.isEmpty {
+            Task {
+                let wd = resolver.resolveWithoutInput(workingDirectoryTemplate: action.workingDirectoryTemplate)
+                let args = resolver.resolveWithoutInput(argumentsTemplate: action.argumentsTemplate)
+                    .map { $0.replacingOccurrences(of: "{recipeDir}", with: wd ?? "") }
+                var request = CommandExecutionRequest(
+                    executablePath: action.executablePath,
+                    arguments: args,
+                    workingDirectory: wd,
+                    timeoutSeconds: action.timeoutSeconds
+                )
+                if let recipeEnvironment, !recipeEnvironment.isEmpty { request.environment = recipeEnvironment }
+                let redactor = SecretRedactor()
+                let redactedRequest = redactor.redactCommand(request, secretValues: secretValues)
+                var result = await runner.run(request: request)
+                result.actionId = action.id
+                result.actionName = self.historyActionName(action: action, metadata: actionMetadata)
+                result.parentRecipeID = actionMetadata?.parentExternalID
+                result.childActionID = actionMetadata?.childActionID
+                result.parentRecipeName = actionMetadata?.parentName
+                result.childActionName = actionMetadata?.childActionID == nil ? nil : action.name
+                result.inputFiles = []
+                if let message = action.successMessage?.trimmingCharacters(in: .whitespacesAndNewlines), !message.isEmpty {
+                    result.completionMessage = message
+                }
+                if !secretValues.isEmpty {
+                    result.stdout = redactor.redact(result.stdout, secretValues: secretValues)
+                    result.stderr = redactor.redact(result.stderr, secretValues: secretValues)
+                }
+                if result.status != .success {
+                    result.stderr = self.failureDebugText(
+                        existingStderr: result.stderr,
+                        action: action,
+                        request: redactedRequest,
+                        secretValues: secretValues
+                    )
+                }
+                try? runHistoryStore.addRun(result)
+                let finalResult = result
+                await MainActor.run { self.actionPanelWindow?.showRunResult(result: finalResult) }
+            }
+            return
+        }
+
         Task {
             var batchHadFailure = false
             for (offset, file) in files.enumerated() {

--- a/Tests/WinegoldNativeTests/KeyboardActionSelectionTests.swift
+++ b/Tests/WinegoldNativeTests/KeyboardActionSelectionTests.swift
@@ -22,4 +22,14 @@ final class KeyboardActionSelectionTests: XCTestCase {
         selection.clamp(count: 0)
         XCTAssertEqual(selection.index, 0)
     }
+    func testDirectSelectionClampsToVisibleActions() {
+        var selection = KeyboardActionSelection()
+        selection.select(index: 2, count: 4)
+        XCTAssertEqual(selection.index, 2)
+        selection.select(index: 8, count: 4)
+        XCTAssertEqual(selection.index, 3)
+        selection.select(index: -2, count: 4)
+        XCTAssertEqual(selection.index, 0)
+    }
+
 }

--- a/Tests/WinegoldNativeTests/PresentedActionTests.swift
+++ b/Tests/WinegoldNativeTests/PresentedActionTests.swift
@@ -34,6 +34,18 @@ final class PresentedActionTests: XCTestCase {
         XCTAssertEqual(policy.present([item], query: "test").count, 1)
     }
 
+    func testSearchRanksExactThenPrefixThenSubstring() {
+        let items = [item("Run test suite"), item("Test project"), item("Test")]
+        XCTAssertEqual(ActionPresentationPolicy().present(items, query: "test").map(\.action.name), ["Test", "Test project", "Run test suite"])
+    }
+
+    func testSearchMatchesExtensionsAndTriggerText() {
+        var png = Action(name: "Convert", acceptedExtensions: ["png"], executablePath: "/bin/zsh")
+        png.triggerExpression = "extension equals \"png\""
+        let item = PresentedAction(action: png)
+        XCTAssertEqual(ActionPresentationPolicy().present([item], query: "png").count, 1)
+    }
+
     private func item(
         _ name: String,
         parent: String? = nil,

--- a/Tests/WinegoldNativeTests/RecipeInvocationTests.swift
+++ b/Tests/WinegoldNativeTests/RecipeInvocationTests.swift
@@ -45,4 +45,36 @@ final class RecipeInvocationTests: XCTestCase {
         action.triggerExpression = "isFile or isDirectory"
         XCTAssertEqual(RecipeInputRequirementResolver().requirement(for: action), .unresolved)
     }
+    func testCardinalityRejectsTooManyItems() {
+        let action = Action(name: "Pair", triggerExpression: "extension equals \"png\"", minimumInputCount: 2, maximumInputCount: 2, executablePath: "/bin/zsh")
+        let items = (0..<3).map { DraggedItem(executionURL: URL(fileURLWithPath: "/tmp/\($0).png")) }
+        guard case let .incompatible(issues) = RecipeInvocationValidator().validate(action, items: items) else { return XCTFail("Expected incompatible") }
+        XCTAssertEqual(issues.first?.message, "This recipe expects exactly 2 items.")
+    }
+
+    func testURLAndTextRequirementsAreDerived() {
+        var url = Action(name: "URL", executablePath: "/bin/zsh")
+        url.triggerExpression = "isURL and host equals \"example.com\""
+        var text = Action(name: "Text", executablePath: "/bin/zsh")
+        text.triggerExpression = "isText and text contains \"todo\""
+        XCTAssertEqual(RecipeInputRequirementResolver().requirement(for: url), .url)
+        XCTAssertEqual(RecipeInputRequirementResolver().requirement(for: text), .text)
+    }
+
+    func testNoInputPlaceholderIsRejected() {
+        let action = Action(name: "Broken", minimumInputCount: 0, executablePath: "/bin/zsh", argumentsTemplate: ["-lc", "echo {input}"])
+        XCTAssertEqual(RecipeTemplateInputValidator().missingInputPlaceholder(in: action), "{input}")
+    }
+
+    func testInputCardinalityParsesAndSerializes() throws {
+        let source = "name: Pair\ninput:\n  min: 2\n  max: 2\ntrigger: 'extension equals \"png\"'\ncmd:\n  exec: echo ok\n"
+        let document = try RecipeParser().parse(text: source)
+        XCTAssertEqual(document.minimumInputCount, 2)
+        XCTAssertEqual(document.maximumInputCount, 2)
+        let serialized = RecipeSerializer().serialize(document)
+        XCTAssertTrue(serialized.contains("input:"))
+        XCTAssertTrue(serialized.contains("  min: 2"))
+        XCTAssertTrue(serialized.contains("  max: 2"))
+    }
+
 }

--- a/Tests/WinegoldNativeTests/RecipeInvocationTests.swift
+++ b/Tests/WinegoldNativeTests/RecipeInvocationTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import WinegoldCore
+
+final class RecipeInvocationTests: XCTestCase {
+    func testTriggerlessRecipeParsesAndSerializesWithoutTrigger() throws {
+        let document = try RecipeParser().parse(text: "name: Clear cache\ncmd:\n  exec: 'echo ok'\n")
+        XCTAssertEqual(document.trigger, "")
+        XCTAssertFalse(RecipeSerializer().serialize(document).contains("trigger:"))
+    }
+
+    func testTriggerlessActionIsValidWithoutInput() {
+        let action = Action(name: "Clear cache", executablePath: "/bin/zsh")
+        XCTAssertEqual(RecipeInvocationValidator().validate(action, items: []), .valid)
+    }
+
+    func testFileRecipeReportsMissingInput() {
+        var action = Action(name: "Convert", executablePath: "/bin/zsh")
+        action.triggerExpression = "extension in {\"jpg\" \"jpeg\"}"
+        XCTAssertEqual(
+            RecipeInvocationValidator().validate(action, items: []),
+            .missingInput(.files(allowedExtensions: ["jpeg", "jpg"]))
+        )
+    }
+
+    func testDirectoryRequirementIsDerived() {
+        var action = Action(name: "Test project", executablePath: "/bin/zsh")
+        action.triggerExpression = "kind equals \"directory\""
+        XCTAssertEqual(RecipeInputRequirementResolver().requirement(for: action), .directories)
+    }
+
+    func testCompatibleAndIncompatibleFilesAreDistinguished() {
+        var action = Action(name: "Convert", executablePath: "/bin/zsh")
+        action.triggerExpression = "extension equals \"png\""
+        let png = DraggedItem(executionURL: URL(fileURLWithPath: "/tmp/a.png"))
+        let jpg = DraggedItem(executionURL: URL(fileURLWithPath: "/tmp/a.jpg"))
+        XCTAssertEqual(RecipeInvocationValidator().validate(action, items: [png]), .valid)
+        guard case let .incompatible(issues) = RecipeInvocationValidator().validate(action, items: [jpg]) else {
+            return XCTFail("Expected incompatible")
+        }
+        XCTAssertEqual(issues.first?.message, "This recipe expects: .png")
+    }
+
+    func testAmbiguousOrDoesNotOverConstrainPicker() {
+        var action = Action(name: "Open", executablePath: "/bin/zsh")
+        action.triggerExpression = "isFile or isDirectory"
+        XCTAssertEqual(RecipeInputRequirementResolver().requirement(for: action), .unresolved)
+    }
+}

--- a/Tests/WinegoldNativeTests/RecipeTests.swift
+++ b/Tests/WinegoldNativeTests/RecipeTests.swift
@@ -53,7 +53,7 @@ final class RecipeTests: XCTestCase {
         XCTAssertEqual(restored.displayOrder, 42)
     }
 
-    func testRepairInvalidRecipeAddsMissingTriggerAndPreservesOtherFields() throws {
+    func testRepairRecipeCanAddTriggerToPreviouslyTriggerlessRecipe() throws {
         let temp = temporaryDirectory()
         let root = temp.appendingPathComponent("recipes")
         let url = root.appendingPathComponent("convert/convert.wg.yml")
@@ -76,7 +76,7 @@ final class RecipeTests: XCTestCase {
         try Migrations(db: db).run()
         let coordinator = RecipeCoordinator(root: root, db: db)
         try coordinator.reconcile()
-        XCTAssertEqual(try coordinator.entries().first?.status, "invalid")
+        XCTAssertEqual(try coordinator.entries().first?.status, "valid")
 
         let draft = try coordinator.repairDraft(at: url)
         XCTAssertEqual(draft.name, "Convert webp to jpg")

--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -364,6 +364,23 @@ URLs may be absolute or relative to the index. Each recipe remains autonomous an
 
 Remote recipes stay linked to their source. Settings shows their source, installed version, local modification state, missing commands, and available updates. Updates are always manual. A locally modified recipe can be kept, replaced, or duplicated before updating. The duplicate receives a new local ID.
 
+
+### Input count
+
+Use `input.min` and `input.max` when a recipe needs a specific number of inputs:
+
+```yml
+name: Compare two PNG files
+input:
+  min: 2
+  max: 2
+trigger: extension equals "png"
+cmd:
+  exec: 'compare "{input}"'
+```
+
+`min` defaults to `1` for recipes with a trigger and `0` for recipes without a trigger. Omit `max` for unlimited selection. Winegold validates the count before evaluating the trigger.
+
 ## Recipes without input
 
 Omit `trigger` when a recipe does not need a file, folder, URL, or text input. These recipes appear in the global palette and run directly.

--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -363,3 +363,17 @@ A compatible repository can expose a JSON index over HTTPS:
 URLs may be absolute or relative to the index. Each recipe remains autonomous and is installed atomically. Published metadata may include `author`, `category`, and `homepage` for the future Winegold Recipes browser.
 
 Remote recipes stay linked to their source. Settings shows their source, installed version, local modification state, missing commands, and available updates. Updates are always manual. A locally modified recipe can be kept, replaced, or duplicated before updating. The duplicate receives a new local ID.
+
+## Recipes without input
+
+Omit `trigger` when a recipe does not need a file, folder, URL, or text input. These recipes appear in the global palette and run directly.
+
+```yml
+name: Clear local cache
+cmd:
+  exec: 'rm -rf "$HOME/Library/Caches/MyApp"'
+```
+
+A missing trigger means **no input**. It is different from `extension in {"*"}`, which still requires an input and accepts any extension.
+
+When a palette recipe requires input, Winegold uses simple file or folder constraints to guide the native picker, then evaluates the complete trigger after selection. Complex conditions such as filename patterns, folder contents, metadata, or `inside` are validated after selection.

--- a/scripts/create-dmg.sh
+++ b/scripts/create-dmg.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+APP="${1:-$ROOT/.build/artifacts/Winegold.app}"
+DMG="${2:-$ROOT/.build/artifacts/Winegold-macOS.dmg}"
+VOLUME_NAME="${3:-Winegold}"
+
+if [[ ! -d "$APP" ]]; then
+    echo "error: app bundle not found at $APP" >&2
+    exit 1
+fi
+
+if [[ ! -x "$APP/Contents/MacOS/WinegoldNative" ]]; then
+    echo "error: app bundle is missing WinegoldNative executable" >&2
+    exit 1
+fi
+
+if ! command -v hdiutil >/dev/null 2>&1; then
+    echo "error: hdiutil is required to create a DMG" >&2
+    exit 1
+fi
+
+STAGING_DIR="$(mktemp -d "${TMPDIR:-/tmp}/winegold-dmg.XXXXXX")"
+cleanup() {
+    rm -rf "$STAGING_DIR"
+}
+trap cleanup EXIT
+
+mkdir -p "$(dirname "$DMG")"
+rm -f "$DMG"
+
+APP_NAME="$(basename "$APP")"
+ditto "$APP" "$STAGING_DIR/$APP_NAME"
+ln -s /Applications "$STAGING_DIR/Applications"
+
+hdiutil create \
+    -volname "$VOLUME_NAME" \
+    -srcfolder "$STAGING_DIR" \
+    -format UDZO \
+    -ov \
+    "$DMG" >/dev/null
+
+if [[ ! -s "$DMG" ]]; then
+    echo "error: disk image was not created at $DMG" >&2
+    exit 1
+fi
+
+echo "$DMG"

--- a/scripts/test-dmg.sh
+++ b/scripts/test-dmg.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+set -euo pipefail
+
+DMG="${1:-}"
+
+if [[ -z "$DMG" ]]; then
+    echo "usage: $0 path/to/Winegold.dmg" >&2
+    exit 2
+fi
+
+if [[ ! -s "$DMG" ]]; then
+    echo "error: DMG not found or empty at $DMG" >&2
+    exit 1
+fi
+
+ATTACH_PLIST="$(mktemp "${TMPDIR:-/tmp}/winegold-dmg-attach.XXXXXX")"
+MOUNT_POINT=""
+cleanup() {
+    if [[ -n "$MOUNT_POINT" && -d "$MOUNT_POINT" ]]; then
+        hdiutil detach "$MOUNT_POINT" >/dev/null || true
+    fi
+    rm -f "$ATTACH_PLIST"
+}
+trap cleanup EXIT
+
+hdiutil attach -readonly -nobrowse -plist "$DMG" > "$ATTACH_PLIST"
+
+entity_count="$(/usr/libexec/PlistBuddy -c 'Print :system-entities' "$ATTACH_PLIST" 2>/dev/null | grep -c 'Dict {' || true)"
+for ((index = 0; index < entity_count; index++)); do
+    candidate="$(/usr/libexec/PlistBuddy -c "Print :system-entities:$index:mount-point" "$ATTACH_PLIST" 2>/dev/null || true)"
+    if [[ -n "$candidate" ]]; then
+        MOUNT_POINT="$candidate"
+        break
+    fi
+done
+
+if [[ -z "$MOUNT_POINT" || ! -d "$MOUNT_POINT" ]]; then
+    echo "error: could not determine mounted DMG path" >&2
+    exit 1
+fi
+
+if [[ ! -d "$MOUNT_POINT/Winegold.app" ]]; then
+    echo "error: Winegold.app is missing from DMG" >&2
+    exit 1
+fi
+
+if [[ ! -x "$MOUNT_POINT/Winegold.app/Contents/MacOS/WinegoldNative" ]]; then
+    echo "error: Winegold.app executable is missing from DMG" >&2
+    exit 1
+fi
+
+if [[ ! -L "$MOUNT_POINT/Applications" ]]; then
+    echo "error: Applications symlink is missing from DMG" >&2
+    exit 1
+fi
+
+if [[ "$(readlink "$MOUNT_POINT/Applications")" != "/Applications" ]]; then
+    echo "error: Applications symlink does not target /Applications" >&2
+    exit 1
+fi
+
+echo "DMG contents verified at $MOUNT_POINT"


### PR DESCRIPTION
## Summary

- add a global searchable recipe palette without requiring drag and drop
- support recipes without a trigger and execute them with zero input
- collect file, folder, URL, or text input from the palette
- guide native file selection with trigger extensions and revalidate afterward
- add explicit `input.min` / `input.max` cardinality
- show clear `Run`, `Choose file`, `Choose folder`, `Enter URL`, and `Enter text` states
- improve search ranking and include recent Winegold runs in palette search
- reject input placeholders in triggerless recipes
- preserve the existing drag-and-drop flow

## Validation

- `swift test`: 244 tests passed
- `swift build --build-system native`: passed
- manual app launch and palette capture: `/tmp/winegold-issue-22-palette.png`

Closes #22
