### PR TITLE
fix: stabilize action panel presentation

### DIFF
--- a/Sources/WinegoldCore/PanelPresentation.swift
+++ b/Sources/WinegoldCore/PanelPresentation.swift
@@ -98,3 +98,21 @@ public struct PanelPresentation: Equatable {
         ].joined(separator: "\n")
     }
 }
+
+public struct PanelAutoHideState: Equatable {
+    public private(set) var hasEnteredPanel = false
+
+    public init() {}
+
+    public mutating func update(isPointerInside: Bool) -> Bool {
+        if isPointerInside {
+            hasEnteredPanel = true
+            return false
+        }
+        return hasEnteredPanel
+    }
+
+    public mutating func reset() {
+        hasEnteredPanel = false
+    }
+}

--- a/Sources/WinegoldNative/ActionPanelWindow.swift
+++ b/Sources/WinegoldNative/ActionPanelWindow.swift
@@ -223,7 +223,12 @@ class ActionPanelWindow: NSPanel, NSWindowDelegate {
         let panelWidth = savedPanelSize.width
         let panelHeight: CGFloat
         if panelVC.shouldShowActions {
-            panelHeight = savedPanelSize.height
+            // Keep the user's saved height, but never open smaller than the current content.
+            // The first visible frame is therefore final and does not need a corrective resize.
+            panelHeight = min(
+                max(savedPanelSize.height, targetFrameHeight(forContentHeight: panelVC.currentContentHeight)),
+                visibleFrame.height - 40
+            )
         } else {
             let contentRect = NSRect(x: 0, y: 0, width: panelWidth, height: idleDropFrameHeight)
             let naturalHeight = frameRect(forContentRect: contentRect).height
@@ -243,7 +248,7 @@ class ActionPanelWindow: NSPanel, NSWindowDelegate {
         // or saved large frame and correcting it on the next run loop causes a blink.
         isProgrammaticFrameChange = true
         setFrame(finalFrame, display: false)
-        layoutIfNeeded()
+        contentView?.layoutSubtreeIfNeeded()
         makeKeyAndOrderFront(nil)
         orderFrontRegardless()
 

--- a/Sources/WinegoldNative/ActionPanelWindow.swift
+++ b/Sources/WinegoldNative/ActionPanelWindow.swift
@@ -221,10 +221,20 @@ class ActionPanelWindow: NSPanel, NSWindowDelegate {
             visibleFrame: visibleFrame
         )
         let panelWidth = savedPanelSize.width
+        // Lay out once while hidden at the final width. Content height can depend on width,
+        // especially after a screen or settings change between initialization and show().
+        let provisionalFrame = NSRect(
+            x: frame.origin.x,
+            y: frame.origin.y,
+            width: panelWidth,
+            height: savedPanelSize.height
+        )
+        isProgrammaticFrameChange = true
+        setFrame(provisionalFrame, display: false)
+        panelVC.view.layoutSubtreeIfNeeded()
+
         let panelHeight: CGFloat
         if panelVC.shouldShowActions {
-            // Keep the user's saved height, but never open smaller than the current content.
-            // The first visible frame is therefore final and does not need a corrective resize.
             panelHeight = min(
                 max(savedPanelSize.height, targetFrameHeight(forContentHeight: panelVC.currentContentHeight)),
                 visibleFrame.height - 40
@@ -246,16 +256,15 @@ class ActionPanelWindow: NSPanel, NSWindowDelegate {
 
         // Decide geometry before the window becomes visible. Showing an off-screen
         // or saved large frame and correcting it on the next run loop causes a blink.
-        isProgrammaticFrameChange = true
         setFrame(finalFrame, display: false)
-        contentView?.layoutSubtreeIfNeeded()
+        panelVC.view.layoutSubtreeIfNeeded()
         makeKeyAndOrderFront(nil)
         orderFrontRegardless()
 
         NSApp.setActivationPolicy(.accessory)
         NSApp.activate(ignoringOtherApps: true)
-        canPersistUserResize = true
         isProgrammaticFrameChange = false
+        canPersistUserResize = true
         logMsg("[ActionPanelWindow] show stableFrame=\(NSStringFromRect(finalFrame))")
         logMsg("[Perf] panel_first_frame uptime=\(ProcessInfo.processInfo.systemUptime)")
 

--- a/Sources/WinegoldNative/ActionPanelWindow.swift
+++ b/Sources/WinegoldNative/ActionPanelWindow.swift
@@ -243,15 +243,14 @@ class ActionPanelWindow: NSPanel, NSWindowDelegate {
         // or saved large frame and correcting it on the next run loop causes a blink.
         isProgrammaticFrameChange = true
         setFrame(finalFrame, display: false)
-        panelVC.view.frame = NSRect(origin: .zero, size: finalFrame.size)
         layoutIfNeeded()
         makeKeyAndOrderFront(nil)
         orderFrontRegardless()
-        isProgrammaticFrameChange = false
-        canPersistUserResize = true
 
         NSApp.setActivationPolicy(.accessory)
         NSApp.activate(ignoringOtherApps: true)
+        canPersistUserResize = true
+        isProgrammaticFrameChange = false
         logMsg("[ActionPanelWindow] show stableFrame=\(NSStringFromRect(finalFrame))")
         logMsg("[Perf] panel_first_frame uptime=\(ProcessInfo.processInfo.systemUptime)")
 

--- a/Sources/WinegoldNative/ActionPanelWindow.swift
+++ b/Sources/WinegoldNative/ActionPanelWindow.swift
@@ -15,6 +15,7 @@ class ActionPanelWindow: NSPanel, NSWindowDelegate {
     private var actionTriggeredSinceShow = false
     private var autoHideTimer: Timer?
     private var pendingAutoHideWorkItem: DispatchWorkItem?
+    private var autoHideState = PanelAutoHideState()
     private var outsideClickMonitor: Any?
     private var hideAfterSuccessWorkItem: DispatchWorkItem?
     private var successHoverTimer: Timer?
@@ -205,10 +206,14 @@ class ActionPanelWindow: NSPanel, NSWindowDelegate {
         isAnimatingOut = false
         actionTriggeredSinceShow = false
         panelState.isCompact = false
+        autoHideState.reset()
         cancelPendingAutoHide()
         cancelHideAfterSuccess()
         stopSuccessHoverMonitor()
+        stopAutoHideMonitor()
+        stopOutsideClickMonitor()
         applyTheme()
+
         let visibleFrame = targetScreen.visibleFrame
         let savedPanelSize = ActionPanelWindow.clampedPanelSize(
             width: CGFloat(settingsStore.panelWidth),
@@ -224,43 +229,35 @@ class ActionPanelWindow: NSPanel, NSWindowDelegate {
             let naturalHeight = frameRect(forContentRect: contentRect).height
             panelHeight = max(compactFrameHeight, min(naturalHeight, visibleFrame.height - 40))
         }
-        let targetX = settingsStore.panelSide == .left ? visibleFrame.minX + 20 : max(visibleFrame.minX, visibleFrame.maxX - panelWidth - 20)
-        var frame = self.frame
-        frame.origin.x = targetX
-        frame.origin.y = max(visibleFrame.minY + 20, visibleFrame.maxY - panelHeight - 20)
-        frame.size = NSSize(width: panelWidth, height: panelHeight)
-        logMsg("[ActionPanelWindow] show visibleFrame=\(NSStringFromRect(visibleFrame)) frame=\(NSStringFromRect(frame))")
-        let finalFrame = frame
-        var startFrame = finalFrame
-        startFrame.origin.x = settingsStore.panelSide == .left ? visibleFrame.minX - panelWidth - 8 : visibleFrame.maxX + 8
-        let shouldSlideIn = !isVisible || self.frame.origin.x >= visibleFrame.maxX - 2
+        let targetX = settingsStore.panelSide == .left
+            ? visibleFrame.minX + 20
+            : max(visibleFrame.minX, visibleFrame.maxX - panelWidth - 20)
+        let finalFrame = NSRect(
+            x: targetX,
+            y: max(visibleFrame.minY + 20, visibleFrame.maxY - panelHeight - 20),
+            width: panelWidth,
+            height: panelHeight
+        )
 
+        // Decide geometry before the window becomes visible. Showing an off-screen
+        // or saved large frame and correcting it on the next run loop causes a blink.
         isProgrammaticFrameChange = true
-        self.setFrame(shouldSlideIn ? startFrame : finalFrame, display: true)
-        self.makeKeyAndOrderFront(nil)
-        self.orderFrontRegardless()
-        logMsg("[Perf] panel_first_frame uptime=\(ProcessInfo.processInfo.systemUptime)")
-        if shouldSlideIn {
-            NSAnimationContext.runAnimationGroup { ctx in
-                ctx.duration = 0.18
-                ctx.timingFunction = CAMediaTimingFunction(name: .easeOut)
-                self.animator().setFrame(finalFrame, display: true)
-            } completionHandler: { [weak self] in
-                self?.isProgrammaticFrameChange = false
-            }
-        } else {
-            isProgrammaticFrameChange = false
-        }
+        setFrame(finalFrame, display: false)
+        panelVC.view.frame = NSRect(origin: .zero, size: finalFrame.size)
+        layoutIfNeeded()
+        makeKeyAndOrderFront(nil)
+        orderFrontRegardless()
+        isProgrammaticFrameChange = false
+        canPersistUserResize = true
+
         NSApp.setActivationPolicy(.accessory)
         NSApp.activate(ignoringOtherApps: true)
-        DispatchQueue.main.async { [weak self] in
-            self?.applyTheme()
-            self?.resizeForCurrentContent(animated: false)
-            self?.canPersistUserResize = true
-            if self?.staysOpenUntilExplicitClose == false {
-                self?.startAutoHideMonitor()
-                self?.startOutsideClickMonitor()
-            }
+        logMsg("[ActionPanelWindow] show stableFrame=\(NSStringFromRect(finalFrame))")
+        logMsg("[Perf] panel_first_frame uptime=\(ProcessInfo.processInfo.systemUptime)")
+
+        if !staysOpenUntilExplicitClose {
+            startAutoHideMonitor()
+            startOutsideClickMonitor()
         }
     }
 
@@ -497,7 +494,8 @@ class ActionPanelWindow: NSPanel, NSWindowDelegate {
         }
 
         let expandedFrame = frame.insetBy(dx: -20, dy: -20)
-        if expandedFrame.contains(NSEvent.mouseLocation) {
+        let pointerInside = expandedFrame.contains(NSEvent.mouseLocation)
+        if !autoHideState.update(isPointerInside: pointerInside) {
             cancelPendingAutoHide()
         } else {
             scheduleAutoHide()

--- a/Tests/WinegoldNativeTests/PanelPresentationTests.swift
+++ b/Tests/WinegoldNativeTests/PanelPresentationTests.swift
@@ -153,3 +153,25 @@ final class PanelPresentationTests: XCTestCase {
         )
     }
 }
+
+final class PanelAutoHideStateTests: XCTestCase {
+    func testDoesNotDismissBeforePointerHasEnteredPanel() {
+        var state = PanelAutoHideState()
+        XCTAssertFalse(state.update(isPointerInside: false))
+        XCTAssertFalse(state.hasEnteredPanel)
+    }
+
+    func testDismissesOnlyAfterPointerEntersThenLeaves() {
+        var state = PanelAutoHideState()
+        XCTAssertFalse(state.update(isPointerInside: true))
+        XCTAssertTrue(state.hasEnteredPanel)
+        XCTAssertTrue(state.update(isPointerInside: false))
+    }
+
+    func testResetRequiresAnewEntry() {
+        var state = PanelAutoHideState()
+        _ = state.update(isPointerInside: true)
+        state.reset()
+        XCTAssertFalse(state.update(isPointerInside: false))
+    }
+}

--- a/Tests/WinegoldNativeTests/PanelPresentationTests.swift
+++ b/Tests/WinegoldNativeTests/PanelPresentationTests.swift
@@ -174,4 +174,18 @@ final class PanelAutoHideStateTests: XCTestCase {
         state.reset()
         XCTAssertFalse(state.update(isPointerInside: false))
     }
+
+    func testRepeatedInsideUpdatesRemainNonDismissing() {
+        var state = PanelAutoHideState()
+        XCTAssertFalse(state.update(isPointerInside: true))
+        XCTAssertFalse(state.update(isPointerInside: true))
+        XCTAssertTrue(state.hasEnteredPanel)
+    }
+
+    func testRepeatedOutsideUpdatesAfterEntryRemainDismissing() {
+        var state = PanelAutoHideState()
+        _ = state.update(isPointerInside: true)
+        XCTAssertTrue(state.update(isPointerInside: false))
+        XCTAssertTrue(state.update(isPointerInside: false))
+    }
 }


### PR DESCRIPTION
## Summary

Stabilize the action panel first frame and prevent the panel from blinking closed immediately after opening. This addresses the confirmed window-presentation part of #28.

## Changes

- Compute the final panel size and position before making the window visible.
- Remove the off-screen slide-in and next-run-loop corrective resize from initial presentation.
- Lay out content using the chosen frame before `makeKeyAndOrderFront`.
- Require the pointer to enter the panel once before mouse-leave auto-dismiss can begin.
- Add unit tests for the auto-hide state machine.

## Testing

- `git diff --check`
- Static audit confirmed no initial `startFrame` or `resizeForCurrentContent(animated: false)` remains in `show()`.
- Swift tests were not runnable on the MJ Linux machine because Swift is not installed.

## AI assistance

Application: ChatGPT; OpenCode
Model: GPT-5.6 Thinking; opencode/north-mini-code-free (initial attempt reviewed and discarded)
